### PR TITLE
docs: amend constitution to v1.3.0 (Commit & PR Consent Gate)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,14 +1,14 @@
 <!--
 Sync Impact Report
 ==================
-Version: 1.1.0 → 1.2.0
-Modified Principles: Added new principle VII (Source Control & Branching)
-Added Sections: Principle VII. Source Control & Branching; Added branching gate to plan template
+Version: 1.2.0 → 1.3.0
+Modified Principles: (new) VIII. Commit & PR Consent Gate
+Added Sections: Principle VIII. Commit & PR Consent Gate; Added consent gate to plan template; Added governance note to tasks template
 Removed Sections: None
 Templates Status:
-  ✅ .specify/templates/plan-template.md - updated (added Source Control & Branching gate)
-  ✅ .specify/templates/spec-template.md - reviewed (already includes Feature Branch field)
-  ✅ .specify/templates/tasks-template.md - reviewed (no change needed)
+  ✅ .specify/templates/plan-template.md - updated (added Commit & PR Consent Gate)
+  ⚪ .specify/templates/spec-template.md - reviewed (no change needed)
+  ✅ .specify/templates/tasks-template.md - updated (assistant/automation consent note)
 Follow-up TODOs: None
 -->
 
@@ -92,6 +92,20 @@ to `master`.
 **Rationale**: Dedicated feature branches provide isolation, clear traceability from spec to code,
 clean review diffs, safer reverts, and predictable CI.
 
+### VIII. Commit & PR Consent Gate
+
+Assistants, scripts, and automation MUST NOT create commits, push branches, open pull requests,
+or merge changes without explicit developer approval. Automation MUST propose "commit/push/PR" as
+the next step once work reaches a meaningful checkpoint and await developer consent.
+
+- Default posture is local iteration until developer signals readiness.
+- Draft PRs MAY be opened only after approval or when explicitly requested by the developer.
+- Commit messages and PR bodies MUST summarize scope and link to the relevant spec/plan/tasks.
+- Any action beyond local file edits (e.g., tagging, releases) REQUIRES developer approval.
+
+**Rationale**: Protects developer iteration cycles, prevents premature publication of incomplete
+work, and maintains clear human oversight over repository history and review cadence.
+
 ## Technology Stack Constraints
 
 **Mandatory Technologies**:
@@ -146,6 +160,11 @@ clean review diffs, safer reverts, and predictable CI.
 - PR MUST originate from a feature branch `[###-feature-name]` and target `master`; no direct
   commits to `master`
 
+**Assistant/Automation Boundaries**:
+
+- Propose commit/push/PR as a next step; DO NOT push, open PRs, or merge without explicit
+  developer approval (see Principle VIII).
+
 **Quality Standards**:
 
 - Functions MUST be pure where possible (no side effects)
@@ -177,4 +196,4 @@ This constitution supersedes all other development practices and conventions.
 - Rejected simpler alternatives MUST be explicitly stated
 - Annual review of constitution alignment with project evolution
 
-**Version**: 1.2.0 | **Ratified**: 2025-10-25 | **Last Amended**: 2025-10-29
+**Version**: 1.3.0 | **Ratified**: 2025-10-25 | **Last Amended**: 2025-10-29

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -40,6 +40,9 @@
 - [ ] **UI & Branding**: UI is responsive (320px–desktop) and includes the MagTech.ai logo from local assets?
 - [ ] **Source Control & Branching**: All work for this feature occurs on a dedicated feature branch
   named `[###-feature-name]` (PR targets `master`; no direct commits to `master`)?
+- [ ] **Commit & PR Consent Gate**: Assistant/automation will ONLY propose commit/push/PR as a next
+  step and WILL NOT push, open PRs, or merge without explicit developer approval (see Constitution
+  Principle VIII)?
 
 **Result**: ✅ PASS | ⚠️ VIOLATIONS REQUIRE JUSTIFICATION IN COMPLEXITY TABLE
 

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -24,21 +24,21 @@ description: "Task list template for feature implementation"
 - Tests organized: `tests/unit/` for pure functions, `tests/integration/` for file loading + UI
 - All paths shown below assume client-side structure
 
-<!-- 
+<!--
   ============================================================================
   IMPORTANT: The tasks below are SAMPLE TASKS for illustration purposes only.
-  
+
   The /speckit.tasks command MUST replace these with actual tasks based on:
   - User stories from spec.md (with their priorities P1, P2, P3...)
   - Feature requirements from plan.md
   - Entities from data-model.md
   - Endpoints from contracts/
-  
+
   Tasks MUST be organized by user story so each story can be:
   - Implemented independently
   - Tested independently
   - Delivered as an MVP increment
-  
+
   DO NOT keep these sample tasks in the generated tasks.md file.
   ============================================================================
 -->
@@ -246,6 +246,8 @@ With multiple developers:
 - [Story] label maps task to specific user story for traceability
 - Each user story should be independently completable and testable
 - Verify tests fail before implementing
-- Commit after each task or logical group
+- Prepare commits after each task or logical group. Assistants/automation MUST propose
+  commit/push/PR as a next step and MUST NOT push, open PRs, or merge without explicit
+  developer approval (see Constitution Principle VIII).
 - Stop at any checkpoint to validate story independently
 - Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence


### PR DESCRIPTION
## Summary
Introduce a governance safeguard requiring explicit developer consent before assistants/automation commit, push, open PRs, or merge. Adds Principle VIII, workflow boundaries, and updates plan/tasks templates.

## Changes
- Constitution: add Principle VIII (Commit & PR Consent Gate) and Assistant/Automation Boundaries under Development Workflow; bump Version to 1.3.0
- Plan template: add Constitution Check item for consent gate
- Tasks template: add assistant/automation consent note under Notes

## Rationale
Prevents premature publication and keeps human-in-the-loop for repo history and review cadence.

## Validation
- Docs-only change; no runtime impact
- Quality gates (build/lint/tests) N/A or unaffected

## Checklist
- [x] Follows branching policy ([004-constitution-consent-gate])
- [x] Updates align with versioning policy (MINOR)
- [x] No unresolved placeholders or bracket tokens

## Preview
See .specify/memory/constitution.md top Sync Impact Report for a concise change summary.